### PR TITLE
Fix crash on sync with 5 subgroups

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -10,6 +10,7 @@ CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=191
 CONFIG_BT_TINYCRYPT_ECC=y
 CONFIG_BT_EXT_ADV=y
 CONFIG_BT_BAP_BROADCAST_ASSISTANT=y
+CONFIG_BT_BAP_BASS_MAX_SUBGROUPS=5
 
 # The following seemed necessary for a successful
 # connection flow on some devices.

--- a/app/src/message_handler.c
+++ b/app/src/message_handler.c
@@ -34,7 +34,7 @@ K_TIMER_DEFINE(heartbeat_timer, heartbeat_timeout_handler, NULL);
 
 static void log_ltv(uint8_t *data, uint16_t data_len);
 
-#define LTV_STR_LEN 512
+#define LTV_STR_LEN 1024
 
 static void log_ltv(uint8_t *data, uint16_t data_len)
 {


### PR DESCRIPTION
TODO: Make logging not crash on overflow
TODO: Find a good maximum for subgroup config