### PR TITLE
Add subgroup selection in web UI

### DIFF
--- a/web/components/source-device-list.js
+++ b/web/components/source-device-list.js
@@ -62,6 +62,7 @@ export class SourceDeviceList extends HTMLElement {
 
 		this.sourceFound = this.sourceFound.bind(this);
 		this.sourceUpdated = this.sourceUpdated.bind(this);
+		this.baseUpdated = this.baseUpdated.bind(this);
 		this.sourceClicked = this.sourceClicked.bind(this);
 
 		const shadowRoot = this.attachShadow({mode: 'open'});
@@ -79,7 +80,7 @@ export class SourceDeviceList extends HTMLElement {
 
 		this.#model.addEventListener('source-found', this.sourceFound);
 		this.#model.addEventListener('source-updated', this.sourceUpdated);
-		this.#model.addEventListener('base-updated', this.sourceUpdated);
+		this.#model.addEventListener('base-updated', this.baseUpdated);
 		this.#model.addEventListener('reset', () => { this.#list.replaceChildren()})
 	}
 
@@ -170,6 +171,20 @@ export class SourceDeviceList extends HTMLElement {
 
 		if (el) {
 			el.refresh();
+		} else {
+			console.warn('source not found!', source);
+		}
+	}
+
+	baseUpdated(evt) {
+		const { source } = evt.detail;
+
+		const items = Array.from(this.#list.querySelectorAll('source-item'));
+
+		const el = items.find(i => i.getModel() === source);
+
+		if (el) {
+			el.baseUpdated();
 		} else {
 			console.warn('source not found!', source);
 		}

--- a/web/lib/message.js
+++ b/web/lib/message.js
@@ -391,6 +391,12 @@ export const tvArrayToLtv = arr => {
 			case BT_DataType.BT_DATA_BROADCAST_CODE:
 			outArr = Array.from(value);	//uint8 array
 			break;
+			case BT_DataType.BT_DATA_BIS_SYNC:
+			outArr = [];
+			value.forEach(v => {
+				outArr.push(...uintToArray(v,4));
+			});
+			break;
 			default:
 			// Don't add fields we don't handle yet
 			continue;

--- a/web/models/assistant-model.js
+++ b/web/models/assistant-model.js
@@ -595,6 +595,31 @@ class AssistantModel extends EventTarget {
 			addr,
 		];
 
+		// If the source has BASE information and there is more than one subgroup,
+		// send 0's for all subgroups except the last, which will be 0xFFFFFFFF (no pref)
+		if (source.base?.subgroups?.length > 1) {
+			const value = [];
+
+			source.base?.subgroups?.forEach(sg => {
+				if (sg.isSelected) {
+					// For each BIS in Subgroup, set bit corresponding to index
+					let bis_sync = 0;
+					sg.bises?.forEach(bis => {
+						if (bis.index) {
+							bis_sync += 1 << (bis.index-1);
+						}
+					})
+					value.push(bis_sync);
+				} else {
+					value.push(0);
+				}
+			});
+
+			tvArr.push({ type: BT_DataType.BT_DATA_BIS_SYNC, value });
+
+			console.log("BIS SYNC TO", value);
+		}
+
 		const payload = tvArrayToLtv(tvArr);
 
 		console.log('Add Source payload', payload)


### PR DESCRIPTION
When obtaining BASE info, create a list of (radio button) selectors for each subgroup.

Pressing the source card outside the selectors will add the source with the selected BIS indexes (found in subgroup)

A card will then look something like:

![image](https://github.com/user-attachments/assets/6fd39bbd-dd3a-42f1-b501-24b69e06208a)
