### PR TITLE
Add PA sync attempt countdown

### DIFF
--- a/app/src/broadcast_assistant.h
+++ b/app/src/broadcast_assistant.h
@@ -13,21 +13,22 @@
 #include <zephyr/bluetooth/audio/audio.h>
 #include <zephyr/bluetooth/audio/csip.h>
 
-#define BT_DATA_RSSI         (BT_DATA_MANUFACTURER_DATA - 1)
-#define BT_DATA_SID          (BT_DATA_MANUFACTURER_DATA - 2)
-#define BT_DATA_PA_INTERVAL  (BT_DATA_MANUFACTURER_DATA - 3)
-#define BT_DATA_ERROR_CODE   (BT_DATA_MANUFACTURER_DATA - 4)
-#define BT_DATA_BROADCAST_ID (BT_DATA_MANUFACTURER_DATA - 5)
-#define BT_DATA_RPA          (BT_DATA_MANUFACTURER_DATA - 6)
-#define BT_DATA_IDENTITY     (BT_DATA_MANUFACTURER_DATA - 7)
-#define BT_DATA_BASE         (BT_DATA_MANUFACTURER_DATA - 8)
-#define BT_DATA_SOURCE_ID    (BT_DATA_MANUFACTURER_DATA - 9)
-#define BT_DATA_BIS_SYNC     (BT_DATA_MANUFACTURER_DATA - 10)
-#define BT_DATA_VOLUME       (BT_DATA_MANUFACTURER_DATA - 11)
-#define BT_DATA_MUTE         (BT_DATA_MANUFACTURER_DATA - 12)
-#define BT_DATA_SIRK         (BT_DATA_MANUFACTURER_DATA - 13)
-#define BT_DATA_SET_SIZE     (BT_DATA_MANUFACTURER_DATA - 14)
-#define BT_DATA_SET_RANK     (BT_DATA_MANUFACTURER_DATA - 15)
+#define BT_DATA_RSSI            (BT_DATA_MANUFACTURER_DATA - 1)
+#define BT_DATA_SID             (BT_DATA_MANUFACTURER_DATA - 2)
+#define BT_DATA_PA_INTERVAL     (BT_DATA_MANUFACTURER_DATA - 3)
+#define BT_DATA_ERROR_CODE      (BT_DATA_MANUFACTURER_DATA - 4)
+#define BT_DATA_BROADCAST_ID    (BT_DATA_MANUFACTURER_DATA - 5)
+#define BT_DATA_RPA             (BT_DATA_MANUFACTURER_DATA - 6)
+#define BT_DATA_IDENTITY        (BT_DATA_MANUFACTURER_DATA - 7)
+#define BT_DATA_BASE            (BT_DATA_MANUFACTURER_DATA - 8)
+#define BT_DATA_SOURCE_ID       (BT_DATA_MANUFACTURER_DATA - 9)
+#define BT_DATA_BIS_SYNC        (BT_DATA_MANUFACTURER_DATA - 10)
+#define BT_DATA_VOLUME          (BT_DATA_MANUFACTURER_DATA - 11)
+#define BT_DATA_MUTE            (BT_DATA_MANUFACTURER_DATA - 12)
+#define BT_DATA_SIRK            (BT_DATA_MANUFACTURER_DATA - 13)
+#define BT_DATA_SET_SIZE        (BT_DATA_MANUFACTURER_DATA - 14)
+#define BT_DATA_SET_RANK        (BT_DATA_MANUFACTURER_DATA - 15)
+#define BT_DATA_PA_SYNC_ATTEMPT (BT_DATA_MANUFACTURER_DATA - 16)
 
 enum {
 	BROADCAST_ASSISTANT_SCAN_IDLE = 0,
@@ -36,13 +37,15 @@ enum {
 	BROADCAST_ASSISTANT_SCAN_CSIS = BIT(2),
 };
 
-int broadcast_assistant_start_scan(uint8_t mode, uint8_t set_size, uint8_t sirk[BT_CSIP_SIRK_SIZE]);
+int broadcast_assistant_start_scan(uint8_t mode, uint8_t set_size, uint8_t sirk[BT_CSIP_SIRK_SIZE],
+				   uint8_t pa_sync_attempt);
 int broadcast_assistant_stop_scanning(void);
 int broadcast_assistant_disconnect_unpair_all(void);
 int broadcast_assistant_connect_to_sink(bt_addr_le_t *bt_addr_le);
 int broadcast_assistant_disconnect_from_sink(bt_addr_le_t *bt_addr_le);
 int broadcast_assistant_add_source(uint8_t sid, uint16_t pa_interval, uint32_t broadcast_id,
 				   bt_addr_le_t *addr, uint8_t num_subgroups, uint32_t *bis_sync);
+int broadcast_assistant_pa_sync(bt_addr_le_t *addr, uint8_t sid, uint16_t interval);
 int broadcast_assistant_remove_source(uint8_t source_id, uint8_t num_subgroups);
 int broadcast_assistant_add_broadcast_code(
 	uint8_t src_id, const uint8_t broadcast_code[BT_AUDIO_BROADCAST_CODE_SIZE]);

--- a/app/src/message.h
+++ b/app/src/message.h
@@ -30,6 +30,7 @@ enum message_sub_type {
 	MESSAGE_SUBTYPE_MUTE                    = 0x0B,
 	MESSAGE_SUBTYPE_UNMUTE                  = 0x0C,
 	MESSAGE_SUBTYPE_START_CSIS_SCAN         = 0x0D,
+	MESSAGE_SUBTYPE_PA_SYNC                 = 0x0E,
 
 	MESSAGE_SUBTYPE_RESET                   = 0x2A,
 

--- a/web/lib/message.js
+++ b/web/lib/message.js
@@ -43,6 +43,7 @@ export const MessageSubType = Object.freeze({
 	MUTE:				0x0B,
 	UNMUTE:				0x0C,
 	START_SET_MEMBER_SCAN:		0x0D,
+	START_PA_SYNC:			0x0E,
 
 	RESET:				0x2A,
 
@@ -91,6 +92,7 @@ export const BT_DataType = Object.freeze({
 	BT_DATA_BROADCAST_NAME:		0x30,	// utf8 (variable len)
 
 	// The following types are created for this app (not standard)
+	BT_DATA_PA_SYNC_ATTEMPT:	0xef,	// uint8
 	BT_DATA_SET_RANK:		0xf0,	// uint8
 	BT_DATA_SET_SIZE:		0xf1,	// uint8
 	BT_DATA_SIRK:			0xf2,	// uint8[6]


### PR DESCRIPTION
PA sync attempt countdown parameter added to scan for sources message. If countdown is set to 0 (default value is 3) then PA sync will not be executed. New PA sync message is added to enable better web UI performance when many sources are present.

Fixes #64