### PR TITLE
Store raw BASE and BIGinfo data

### DIFF
--- a/web/lib/message.js
+++ b/web/lib/message.js
@@ -326,10 +326,12 @@ const parseLTVItem = (type, len, value) => {
 			break;
 		case BT_DataType.BT_DATA_BIG_INFO:
 			item.value = parse_big_info(value);
+			item.value.raw_data = Array.from(value);
 			console.log('BIG Info received', value, JSON.stringify(item.value, null, 2));
 			break;
 		case BT_DataType.BT_DATA_BASE:
 			item.value = parse_base(value);
+			item.value.raw_data = Array.from(value);
 			console.log('BASE received', value, JSON.stringify(item.value, null, 2));
 			break;
 		default:


### PR DESCRIPTION
When receiving the BASE and BIGinfo, also store
the raw data in a raw_data field in the source
data object.